### PR TITLE
Mac: remove suspicious unwrap_or_default

### DIFF
--- a/src-tauri/src/mac_key_interceptor.rs
+++ b/src-tauri/src/mac_key_interceptor.rs
@@ -449,8 +449,12 @@ fn handle_key_event(
             }
 
             let opposite_key_value = cloned_key_state.opposite_key_value;
-            let opposite_key_mapping = cloned_key_state.opposite_key_mapping.unwrap_or_default();
-            let mapping_opposite_key_state = opposite_key_states.get_mut(&opposite_key_mapping);
+            let mapping_opposite_key_state =
+                cloned_key_state
+                    .opposite_key_mapping
+                    .and_then(|opposite_key_mapping| {
+                        opposite_key_states.get_mut(&opposite_key_mapping)
+                    });
             let opposite_key_state = match mapping_opposite_key_state {
                 Some(value) => value,
                 None => opposite_key_states.get_mut(&opposite_key_value).unwrap(),


### PR DESCRIPTION
This use of `unwrap_or_default` in `mac_key_interceptor.rs` looks very suspicious:
```rust
let opposite_key_mapping = cloned_key_state.opposite_key_mapping.unwrap_or_default();
```
the type is `i64`, and the default of `i64` is `0`, which corresponds with the `A` key.
and it's the A key that was behaving weirdly for me in these situations:

> If I hold left, and toggle the right button on and off, it works just fine, wiggling as I would expect.
> But if I hold right, and toggle the left button on and off, it does a half-wiggle and then stops when I release left and go back to just holding right.
> 
> idk what I did wrong, but somehow I ended up with my character perpetually walking left after some sequence of wiggles and then letting go of all keys